### PR TITLE
2023-05-06 fix fields_view_get implementation, add post init hook

### DIFF
--- a/product_form_pricelist_percent_change/__init__.py
+++ b/product_form_pricelist_percent_change/__init__.py
@@ -1,3 +1,10 @@
 #  Copyright 2023 Francesco Ballerini
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import models
+from odoo import api, SUPERUSER_ID
+
+
+def _post_init_hook(cr, registry):
+    """ Enable user input div visibility on pre-existent pricelist rules """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.cr.execute("""UPDATE product_pricelist_item SET show_percent_change_button = true;""")

--- a/product_form_pricelist_percent_change/__manifest__.py
+++ b/product_form_pricelist_percent_change/__manifest__.py
@@ -17,6 +17,7 @@
         "views/product_template_view.xml",
         "views/product_pricelist_views.xml",
     ],
+    'post_init_hook': '_post_init_hook',
     "application": False,
     "installable": True,
     "license": "AGPL-3",

--- a/product_form_pricelist_percent_change/models/product.py
+++ b/product_form_pricelist_percent_change/models/product.py
@@ -10,29 +10,77 @@ class ProductTemplate(models.Model):
 
     @api.model
     def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
+            self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
-        """Check which mode render the item ids view:
+        """ Adjust editable attribute depending on current pricelist setting:
 
-        - editable tree-view for basic pricelist users that only
-          will get access to fixed price feature
+        In product views:
 
-        -  for advanced pricelist user removing the 'editable'
-        attribute will open the full form-view pricelist item"""
+        - Always set editable=bottom for basic pricelist
 
-        res = super(ProductTemplate, self).fields_view_get(
+        - Always remove editable attribute for advanced pricelists, this will
+        lead to the pricelist item form-view when clicking on One2many field
+        `fixed_pricelist_item_ids`
+
+        Todo: should remove 'editable' attr in xml after last refactor?
+        """
+
+        res = super().fields_view_get(
             view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
         )
-        pricelist_advanced = self.user_has_groups("product.group_sale_pricelist")
-        if view_type != "form" or pricelist_advanced:
+
+        if view_type != "form":
             return res
 
-        # actually we add the editable, because this module removes it by default
         doc = etree.XML(
             res["fields"]["fixed_pricelist_item_ids"]["views"]["tree"]["arch"]
         )
-        for node in doc.xpath("//tree"):
-            node.set("editable", "bottom")
+
+        pricelist_advanced = self.user_has_groups("product.group_sale_pricelist")
+
+        if pricelist_advanced:
+            for node in doc.xpath("//tree"):
+                node.attrib.pop("editable", None)
+        else:
+            for node in doc.xpath("//tree"):
+                node.attrib["editable"] = "bottom"
+        res["fields"]["fixed_pricelist_item_ids"]["views"]["tree"][
+            "arch"
+        ] = etree.tostring(doc, encoding="unicode")
+        return res
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def fields_view_get(
+            self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        # This has to be replicated otherwise logic will not be applied
+        # to product.product views. This is a verbatim copy of template
+        # implementation, but we don't delegate to product template class
+        # in order to manage view processing individually for both models.
+
+        res = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+
+        if view_type != "form":
+            return res
+
+        doc = etree.XML(
+            res["fields"]["fixed_pricelist_item_ids"]["views"]["tree"]["arch"]
+        )
+
+        pricelist_advanced = self.user_has_groups("product.group_sale_pricelist")
+
+        if pricelist_advanced:
+            for node in doc.xpath("//tree"):
+                node.attrib.pop("editable", None)
+        else:
+            for node in doc.xpath("//tree"):
+                node.attrib["editable"] = "bottom"
         res["fields"]["fixed_pricelist_item_ids"]["views"]["tree"][
             "arch"
         ] = etree.tostring(doc, encoding="unicode")

--- a/product_form_pricelist_percent_change/models/product_pricelist_item.py
+++ b/product_form_pricelist_percent_change/models/product_pricelist_item.py
@@ -621,9 +621,6 @@ class ProductPricelistItem(models.Model):
                     view_ref = module_prefix + view_name
                     view_id = self.env.ref(view_ref).id
 
-            else:
-                view_id = self.env.ref("product.product_pricelist_item_form_view").id
-
         res = super(ProductPricelistItem, self).fields_view_get(
             view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
         )


### PR DESCRIPTION
Both fields_view_get() implementation ProductTemplate and ProductPricelistItem had issues. 
ProductPricelistItem implementation had an else which forced the render of the
'product_pricelist_item_form_view' when it does not find the model key in the context (coming from one2many field). This issue wasn't allowing correct view-resolution, so I removed else to restore the normal view resolution in absence of one2many context key. ProductTemplate fields_view_get() implementation has been improved and also implemented on Product product.

*Added post init hook to manage technical field in commit b38b7af for pre-existing rule at module installation.